### PR TITLE
Dont import empty bams

### DIFF
--- a/modules/VertRes/Pipelines/Import_iRODS.pm
+++ b/modules/VertRes/Pipelines/Import_iRODS.pm
@@ -129,6 +129,13 @@ sub get_files
         my $outfile = $1;
         if ( -e $outfile ) { next; }
 
+        # Check if the BAM contains any reads.
+        if( $irods->get_total_reads($ifile) == 0)
+        {
+          $self->log("No reads in BAM file");
+          next;
+        }
+
         # Get the BAM index
         my $bai = $ifile;
         $bai =~ s/\.bam$/.bai/i;

--- a/modules/VertRes/Wrapper/iRODS.pm
+++ b/modules/VertRes/Wrapper/iRODS.pm
@@ -227,3 +227,22 @@ sub get_file {
     return system(@args);
 }
 
+
+=head2 get_total_reads
+
+    Description : returns the total nubmer of reads in the bam file
+    Arg [1]     : irods file location
+    Example     : my $total_reads = $irods->get_total_reads('/seq/1234/1234_5.bam');
+    Returntype  : integer number of reads
+
+=cut
+
+sub get_total_reads {
+  my ($self, $file) = @_;
+  my $cmd = join "/",($self->{icommands},"imeta ls -d $file total_reads | grep value | awk '{ print $2 }'");
+
+  my $total_reads = `$cmd`;
+  chomp $total_reads;
+  return $total_reads;
+}
+


### PR DESCRIPTION
No point in importing empty bams because they have a header and then move on to the next stage and fail with a strange error. Instead just skip over them and write to STDERR so we can investigate if we really want to.
