### PR TITLE
Change from samtools pileup to mpileup for genome coverage in TrackQC_Fastq.pm

### DIFF
--- a/modules/VertRes/Pipelines/TrackQC_Fastq.pm
+++ b/modules/VertRes/Pipelines/TrackQC_Fastq.pm
@@ -761,7 +761,7 @@ sub run_graphs
     my $outdir       = "$lane_path/$sample_dir/";
 
     # Genome covered 
-    Utils::CMD("$samtools pileup $outdir/$name.bam | wc -l > $outdir/$name.cover");
+    Utils::CMD("$samtools mpileup $outdir/$name.bam | wc -l > $outdir/$name.cover");
     
 }
 


### PR DESCRIPTION
Changed from samtools pileup to mpileup for finding genome coverage in Fastq QC pipeline.
