### PR TITLE
Changed method for detecting single-ended files for plot-bamcheck.

### DIFF
--- a/scripts/plot-bamcheck
+++ b/scripts/plot-bamcheck
@@ -259,12 +259,15 @@ sub plot_qualities
     push @lines, sprintf "'' using 1:%d with lines lw 2 lc rgb '#4affda' t ''",$nrows+2;
     my $lines = join(',', @lines);
     
-    my $is_paired = 1;
-    if(@lf <= 1)
+    # Set single-ended or paired based on last fragment qualities
+    my $is_paired = 0;
+    IS_PAIRED: foreach my $cycle (@lvals)
     {
-      $is_paired = 0;
+	foreach (@{$cycle})
+	{
+	    if($_){ $is_paired = 1; last IS_PAIRED; }
+	}
     }
-
     
     # Create the gnuplot script. Quick solution: the script relies on backticks and unix commands, may be changed in future
     open(my $fh,'>',$$args{gp}) or error("$$args{gp}: $!");


### PR DESCRIPTION
Detect single-ended files from last fragment qualities. (All zero for single-ended files.)
