### PR TITLE
Updated schema to support 'Single ended hi seq sequencing'

### DIFF
--- a/modules/VRTrack/VRTrack.pm
+++ b/modules/VRTrack/VRTrack.pm
@@ -45,7 +45,7 @@ use VRTrack::Lane;
 use VRTrack::File;
 use VRTrack::Core_obj;
 
-use constant SCHEMA_VERSION => '16';
+use constant SCHEMA_VERSION => '17';
 
 our $DEFAULT_PORT = 3306;
 
@@ -1084,7 +1084,7 @@ CREATE TABLE `seq_request` (
   `library_id` smallint(5) unsigned,
   `multiplex_pool_id` smallint(5) unsigned,
   `ssid` mediumint(8) unsigned DEFAULT NULL,
-  `seq_type` enum('Single ended sequencing','Paired end sequencing','HiSeq Paired end sequencing','MiSeq sequencing') DEFAULT 'Single ended sequencing',
+  `seq_type` enum('Single ended sequencing','Paired end sequencing','HiSeq Paired end sequencing','MiSeq sequencing','Single ended hi seq sequencing') DEFAULT 'Single ended sequencing',
   `seq_status` enum('unknown','pending','started','passed','failed','cancelled','hold') DEFAULT 'unknown',
   `note_id` mediumint(8) unsigned DEFAULT NULL,
   `changed` datetime NOT NULL,

--- a/sql/VRTrack_schema_16_to_17.sql
+++ b/sql/VRTrack_schema_16_to_17.sql
@@ -1,0 +1,4 @@
+ALTER TABLE seq_request MODIFY seq_type ENUM('Single ended sequencing','Paired end sequencing','HiSeq Paired end sequencing','MiSeq sequencing','Single ended hi seq sequencing')  NOT NULL; 
+DROP VIEW if EXISTS `latest_seq_request`;
+create view latest_seq_request as select * from seq_request where latest=true;
+update schema_version set schema_version=17;


### PR DESCRIPTION
Change from schema 16 to 17.

Change to VRTrack.pm module incrementing schema version to 17 and change to schema().
Added sql script to update tracking databases.
