### PR TITLE
when tag changes choose current aliquot

### DIFF
--- a/modules/Sfind/Library.pm
+++ b/modules/Sfind/Library.pm
@@ -330,7 +330,7 @@ around BUILDARGS => sub {
         library_tube.sample_name,
         library_tube.scanned_in_date,
         library_tube.public_name from current_library_tubes  as library_tube
-    join aliquots as aliquot on aliquot.receptacle_type = "library_tube" and aliquot.library_internal_id = library_tube.internal_id
+    join aliquots as aliquot on aliquot.receptacle_type = "library_tube" and aliquot.library_internal_id = library_tube.internal_id and aliquot.is_current = 1
     left join current_tags as tags on tags.internal_id = aliquot.tag_internal_id
     where library_tube.internal_id = ? order by aliquot.tag_internal_id desc limit 1];
 


### PR DESCRIPTION
Sfind didnt look at the most current aliquot if a multiplexed library had its tag changed.
