### PR TITLE
Set Import_iRODS_fastq campress_and_validate script to reserve 100Mb.

### DIFF
--- a/modules/VertRes/Pipelines/Import_iRODS_fastq.pm
+++ b/modules/VertRes/Pipelines/Import_iRODS_fastq.pm
@@ -287,8 +287,8 @@ sub compress_and_validate {
     my $fastq_base = $self->{lane};
     
     my $memory = $self->{memory};
-    if (! defined $memory || $memory < 50) {
-        $memory = 50;
+    if (! defined $memory || $memory < 100) {
+        $memory = 100;
     }
     my $queue = $memory >= 30000 ? "hugemem" : "normal";
     


### PR DESCRIPTION
Added additional margin of error for script.
