### PR TITLE
Tophat temp directories

### DIFF
--- a/modules/VertRes/Wrapper/tophat.pm
+++ b/modules/VertRes/Wrapper/tophat.pm
@@ -156,7 +156,7 @@ sub generate_sam {
     my @fqs = ($fq1, $fq2);
     
     my($filename, $base_directory, $suffix) = fileparse($out);
-    $directories = tempdir( DIR => $base_directory );
+    my $directories = tempdir( DIR => $base_directory );
     
     unless (-s $out) {
         my $e = 70;


### PR DESCRIPTION
When your mapping and its split, run each tophat instance in a different temp directory, otherwise it gets confused.
