### PR TITLE
Smalt custom parameters

### DIFF
--- a/modules/VertRes/Utils/Mappers/smalt.pm
+++ b/modules/VertRes/Utils/Mappers/smalt.pm
@@ -162,14 +162,13 @@ sub do_mapping {
     }
 
     my %args = $self->_do_mapping_args(\%do_mapping_args, %input_args);
+
+    # custom index and mapping parameters
     $args{mapper_index_suffix} = $input_args{mapper_index_suffix} if(defined($input_args{mapper_index_suffix}));
+    $args{mapper_index_params} = $input_args{mapper_index_params} if(defined($input_args{mapper_index_params}));
     $args{additional_mapper_params} = $input_args{additional_mapper_params} if(defined($input_args{additional_mapper_params} ));
+
     my $wrapper = $self->wrapper;
-    
-    if(defined($input_args{mapper_index_params}) && defined ($input_args{mapper_index_suffix}))
-    {
-      $wrapper->setup_custom_reference_index($input_args{ref}, $input_args{mapper_index_params},$input_args{mapper_index_suffix})
-    }
     $wrapper->do_mapping(%args);
     $self->_add_command_line($wrapper->command_line());
 

--- a/modules/VertRes/Wrapper/smalt.pm
+++ b/modules/VertRes/Wrapper/smalt.pm
@@ -203,7 +203,7 @@ sub generate_sam {
             }
         }
         my $hash_name;
-        if(defined($other_args{mapper_index_suffix}))
+        if(defined($other_args{mapper_index_suffix}) && defined($other_args{mapper_index_params}))
         {
             $self->setup_custom_reference_index($ref,$other_args{mapper_index_params},$other_args{mapper_index_suffix});
             $hash_name = $ref.'.'.$other_args{mapper_index_suffix};


### PR DESCRIPTION
Removed redundant code custom index generation for smalt.
Correct parameters passed for custom index generation on demand in smalt wrapper.
