### PR TITLE
.pseudo_genome.done is required only if the pseudo_genome task is active

### DIFF
--- a/modules/VertRes/Pipelines/SNPs.pm
+++ b/modules/VertRes/Pipelines/SNPs.pm
@@ -1497,11 +1497,16 @@ sub cleanup_requires {
 
     # need a done file from each caller
     for my $task (keys %{$self->{task}}) {
-        next if ($task eq "update_db" or $task eq "cleanup" or $task eq "pseudo_genome");
+        next if ($task eq "update_db" or $task eq "cleanup");
+
+        if ($task eq "pseudo_genome") {
+            #adding a "." prefix, otherwise "cleanup" would delete this file
+            push @requires, ".$task.done";
+            next;
+        }
+
         push @requires, "$task.done";
-    }
-   
-    push @requires, ".pseudo_genome.done";
+    }   
     return \@requires;
 }
 


### PR DESCRIPTION
cleanup method required .pseudo_genome.done file even when the task was not run. This has been fixed in this commit.
