### PR TITLE
import nonhuman bams

### DIFF
--- a/modules/VertRes/Pipelines/Import_iRODS_fastq.pm
+++ b/modules/VertRes/Pipelines/Import_iRODS_fastq.pm
@@ -385,10 +385,13 @@ sub update_db
     my @bam_suffix   = ('bam','bam.bai','bam.md5','bam.bc');
     my @fastq_suffix = ('fastq','fastq.fastqcheck');
 
+    my $bam = $self->{files}->[0];
+    my $nonhuman = ($bam =~ /_nonhuman.bam$/) ? '_nonhuman':''; # set for nonhuman bams
+
     for my $suffix (@bam_suffix)
     {
 	# Remove bams
-	Utils::CMD(qq[rm $lane_path/$$self{lane}.$suffix]);
+	Utils::CMD(qq[rm $lane_path/$$self{lane}$nonhuman.$suffix]);
     }
 
     for my $suffix (@fastq_suffix)


### PR DESCRIPTION
Fix for import of nonhuman bams using the Import_iRODS_fastq pipeline. 
Deletes bam imported from iRODS when tracking database is updated.
