### PR TITLE
iget redirects to best server when getting bam file

### DIFF
--- a/modules/VertRes/Wrapper/iRODS.pm
+++ b/modules/VertRes/Wrapper/iRODS.pm
@@ -225,8 +225,9 @@ sub get_file {
     # -K: checksum
     # -Q: use UDP rather than TCP
     # -f: force overwrite
+    # -I: redirect connection to best server
     #my @args = ($cmd, "-K", "-Q", "-f", $file, $dest);
-    my @args = ($cmd, "-K", "-f", $file, $dest);
+    my @args = ($cmd, "-K", "-f", "-I", $file, $dest);
     return system(@args);
 }
 


### PR DESCRIPTION
The -I option for iget redirects the connection if an iRODS server has failed.
