### PR TITLE
Fix for mapfind results summary file, return NA if target_bases_mapped u...

### DIFF
--- a/modules/Pathogens/Reports/Mapping/Row.pm
+++ b/modules/Pathogens/Reports/Mapping/Row.pm
@@ -234,8 +234,10 @@ sub _build_genome_covered
     if($self->is_mapping_complete)
     {
 	my $target_bases_mapped = $self->mapstats->target_bases_mapped;
+	if($target_bases_mapped){
 	my $genome_covered = $self->reference_size ? ($target_bases_mapped/$self->reference_size)*100 : undef;
 	$genome_cover_perc = sprintf("%5.2f", $genome_covered) if defined $genome_covered;
+	}
     }
     return $genome_cover_perc;
 }


### PR DESCRIPTION
Fix for mapfind results summary file so NA returned when target_bases_mapped is NULL in bwa QC mappings.
