### PR TITLE
vrtracking_tool - mapped and snp_called

### DIFF
--- a/scripts/vrtracking_tool
+++ b/scripts/vrtracking_tool
@@ -120,7 +120,7 @@ use Carp;
 
 my ($config, $config_data, $stage, $help, $delete, $verbose, $root, $db, $test);
 #values for $stage that involve *resetting* db flags and file deletion
-my @stages =  ('import', 'qc', 'genotype', 'improved', 'snp_called', 'assembled');
+my @stages =  ('import', 'qc', 'genotype', 'improved', 'snp_called', 'assembled', 'mapped');
 #values for $stage that can EITHER have flags reset as above, OR have VRTrack objects and whole directories deleted, depending on whether the --delete/-del flag is set)
 my @entities = ('lane', 'library', 'sample', 'study');
 
@@ -296,6 +296,18 @@ while (<>){
                                               "^_assembly_update_db_done\$",  # replaced _update_db_done      
                                               "^velvet_assembly_logfile\.txt\$",
                                               "^velvet_assembly\$"],
+                                mapped => ["^\._mark_duplicates_[ps]e_[0-9]+.[oe].archive\$",
+                                           "^\._statistics_[0-9]+\.[ps]e\.raw\.sorted\.bam\.[oe]\.archive\$",
+                                           "^\._merge_[ps]e_[0-9]+\.[oe]\.archive\$",
+                                           "^\._map_[ps]e_[0-9]+_[0-9]+\.[oe]\.archive\$",
+                                           "^\._split_[ps]e_[0-9]+\.[oe]\.archive\$",
+                                           "^[0-9]+\.[ps]e\.markdup\.bam\$","^[0-9]+\.[ps]e\.markdup\.bam\.bai\$",
+                                           "^[0-9]+\.[ps]e\.raw\.sorted\.bam\$","^[0-9]+\.[ps]e\.raw\.sorted\.bam\.bai\$",
+                                           "^[0-9]+\.[ps]e\.raw\.sorted\.bam_graphs\$",
+                                           "^[0-9]+\.[ps]e\.raw\.sorted\.bam\.(cover|bc|bas|flagstat)\$",
+                                           "^\.[0-9]+\.[ps]e\.raw\.sorted\.bam\.checked\$",
+                                           "^\.mapping_complete_[ps]e_[0-9]+\$",
+                                           "^\.split_complete_[ps]e_[0-9]+\$"],
     		);
     		
     		my @files_del = $entity_op ? @{$files_deleted{$reset_stage}} : @{$files_deleted{$stage}};	
@@ -318,7 +330,7 @@ while (<>){
 						unless ($test) {remove_tree($filepath) or die "Unable to delete the directory $filepath, error = $!\n"};
 						$logger->info("Removed directory: ", $filepath);
 					}
-					elsif ( -e $filepath ) {
+					elsif ( -e $filepath || (!-e $filepath && -l $filepath) ) {
 						unless ($test) {unlink $filepath or die "Unable to delete $filepath, error = $!\n"}; 
 						$logger->info("Deleted: ", $filepath);
 					}
@@ -330,8 +342,8 @@ while (<>){
     			for my $flag (@reset_flags) {
     				unless ($test) {
     					$reset_obj->is_processed($flag => 0);
-    					if ( ($reset_stage eq 'qc' || $reset_stage eq 'all') && $reset_obj->isa('VRTrack::Lane')) {
-    						$reset_obj->genotype_status('unchecked');
+    					if ( ($reset_stage eq 'qc' || $reset_stage eq 'mapped' || $reset_stage eq 'all') && $reset_obj->isa('VRTrack::Lane')) {
+    						$reset_obj->genotype_status('unchecked') unless $reset_stage eq 'mapped';
 						$logger->info("Deleted ".$flag." mapstats for the lane ".$reset_obj->name()) if delete_mapstats_entries($reset_obj,$flag);
     					}	
     					$reset_obj->update;


### PR DESCRIPTION
Vrtracking tool removes pathogens files when resetting snp_called.

Vrtracking tool resets mapped flag, deletes mapped entries in the mapstats table and removes files from disk.

Note: File deletion set to remove symlinks to nonexistent files - the -e test returns false for broken symlinks and we break the symlinks when deleting mapping files from the 'mapped' stage.
