### PR TITLE
Replaced reference size check.

### DIFF
--- a/t/Pathogens/GenomeCoverage.t
+++ b/t/Pathogens/GenomeCoverage.t
@@ -15,8 +15,6 @@ ok my $gc_err = Pathogens::Parser::GenomeCoverage->new( bamcheck => 'a_file_that
 throws_ok {$gc_err->coverage()} qr/GenomeCoverage::coverage/,'coverage throws for nonexistent file';
 throws_ok {$gc_err->coverage_depth()} qr/GenomeCoverage::coverage/,'coverage_depth throws for nonexistent file';
 throws_ok {$gc_err->ref_size('xxx')} qr/GenomeCoverage::ref_size/,'throws for garbage input';
-ok my $gc_err_2 = Pathogens::Parser::GenomeCoverage->new( bamcheck => 't/data/io_test.txt' ), 'create instance for non-bamcheck file';
-throws_ok {$gc_err_2->coverage()} qr/GenomeCoverage::_build__bc_coverage/,'coverage throws for non-bamcheck file';
 
 
 # test coverage()
@@ -31,11 +29,11 @@ is join(',',@cover_bins), '248,165,194,221,145', 'coverage for unsorted bins giv
 # test coverage_depth()
 throws_ok {$gc->coverage_depth} qr/Reference size must be set for mean coverage depth calculation./,'coverage_depth throws if ref_size not set.'; 
 ok $gc->ref_size(200), 'set ref_size too low.';
-throws_ok {$gc->coverage_depth} qr/Total bases found by bamcheck exceeds size of reference sequence./,'coverage_depth throws if ref_size too low';
+throws_ok {$gc->coverage_depth} qr/Total bases found exceeds size of reference sequence./,'coverage_depth throws if ref_size too low';
 ok $gc->ref_size(300), 'set ref_size to correct value.';
 ok my ($cover_bases,$depth_mean,$depth_sd) = $gc->coverage_depth(), 'coverage_depth runs';
 is sprintf("%d,%.2f,%.2f",$cover_bases,$depth_mean,$depth_sd),'248,167.00,118.05','coverage_depth gives expected result';
-
+is $gc->_bam_coverage, 248, 'Bases covered check from samtools gives expected result';
 
 done_testing();
 exit;


### PR DESCRIPTION
Coverage depth function checks bases found by samtools depth vs reference size.
Removed test for zero coverage as module now allows for no coverage.
