### PR TITLE
Import read filtering

### DIFF
--- a/modules/VertRes/Pipelines/Import_iRODS_fastq.pm
+++ b/modules/VertRes/Pipelines/Import_iRODS_fastq.pm
@@ -266,6 +266,9 @@ unlink("pf_fail.sam");
 VertRes::Wrapper::samtools->new()->sort(qq[$in_bam], qq[sorted], n => 1, m => $samtools_sorting_memory);
 system("mv sorted.bam $in_bam");
 
+unlink(qq[rm $in_bam.bc]);
+system(qq[$$self{bamcheck} $in_bam >  $in_bam.bc]);
+
 VertRes::Utils::Sam->new(verbose => 1, quiet => 0, java_memory => $java_mem )->bam2fastq(qq[$in_bam], qq[$fastq_base]);
 };
     unless($self->is_paired){


### PR DESCRIPTION
Reads which have the instrument QC fail flag set (PF) have their quality scores set to zero and the bases set to N. 
If there are secondary alignments (duplicate reads from tophat), remove them so that the number of reads is consistent with the value in irods.
