### PR TITLE
Add iva_qc and new parameters for iva call

### DIFF
--- a/modules/VertRes/Pipelines/Assembly.pm
+++ b/modules/VertRes/Pipelines/Assembly.pm
@@ -144,7 +144,8 @@ our %options = (
                 QUASR_exec	     => '/software/pathogen/external/apps/usr/local/QUASR/readsetProcessor.jar',
                 trimmomatic_jar  => '/software/pathogen/external/apps/usr/local/Trimmomatic-0.32/trimmomatic-0.32.jar',
                 iva_qc_exec		 => '/software/pathogen/external/bin/iva_qc',
-                kraken_db		 => 'link to kraken db',
+                iva_qc	=> 0,
+                kraken_db => '/lustre/scratch108/pathogen/pathpipe/kraken/assemblyqc_fluhiv_20150728',
                 adapters_file    => '/lustre/scratch108/pathogen/pathpipe/usr/share/solexa-adapters.fasta',
                 primers_file     => '',
                 remove_primers   => 0,
@@ -159,10 +160,9 @@ our %options = (
                 iva_seed_ext_min_ratio => 2,
                 iva_ext_min_cov        => 5,
                 iva_ext_min_ratio      => 2,
-                iva_insert_size		   => 800,
-                iva_strand_bias        => 0,
-                iva_qc	=> 0,
-                kraken_db => '/path/to/kraken',
+                iva_insert_size		   => 500,
+                iva_strand_bias        => 0.1,
+ 
                );
 
 sub new {
@@ -600,7 +600,7 @@ sub improve_assembly
   
  
   
-  }
+  
 }
 
 

--- a/modules/VertRes/Pipelines/Assembly.pm
+++ b/modules/VertRes/Pipelines/Assembly.pm
@@ -356,6 +356,7 @@ use Cwd;
 use File::Path qw(make_path remove_tree);
 use Bio::AssemblyImprovement::Util::FastqTools;
 use Bio::AssemblyImprovement::Util::OrderContigsByLength;
+use Bio::AssemblyImprovement::IvaQC::Main;
 
 my \$assembly_pipeline = VertRes::Pipelines::Assembly->new();
 system("rm -rf $self->{assembler}_assembly_*");
@@ -430,14 +431,14 @@ system("mv $tmp_directory/$self->{assembler}_assembly $output_directory");
 # Run iva_qc if needed
 if(defined($self->{iva_qc}) && $self->{iva_qc} && defined($self->{kraken_db})) 
 {
-  	my $iva_qc = Bio::AssemblyImprovement::IvaQC::Main->new(
+  	my \$iva_qc = Bio::AssemblyImprovement::IvaQC::Main->new(
     			'db'      			  => $self->{kraken_db},
     			'forward_reads'       => qq[$tmp_directory].'/forward.fastq',
     			'reverse_reads'       => qq[$tmp_directory].'/reverse.fastq',
     			'assembly'			  => \$assembler->optimised_assembly_file_path(),
     			'iva_qc_exec'         => $self->{iva_qc_exec},
     			);
-    $iva_qc->run();
+    \$iva_qc->run();
 }
 
 unlink(qq[$tmp_directory].'/forward.fastq');

--- a/modules/VertRes/Utils/Assemblers/iva.pm
+++ b/modules/VertRes/Utils/Assemblers/iva.pm
@@ -89,6 +89,12 @@ sub optimise_parameters
     "--ext_min_ratio",      (defined($self->{iva_ext_min_ratio}))      ? $self->{iva_ext_min_ratio}      : 2,
   ));
   
+  # insert size
+  my $insert_size_opt = join(' ', ("--max_insert", (defined($self->{iva_insert_size}))   ? $self->{iva_insert_size}   : 500);
+  
+  # strand bias opt
+  my $strand_bias_opt = join(' ', ("--strand_bias", (defined($self->{iva_strand_bias}))   ? $self->{iva_strand_bias}   : 0);
+  
   `$self->{optimiser_exec} $extension_opts $trimming_opts --fr $self->{files_str} --threads $num_threads iva_assembly`;
   File::Copy::move(File::Spec->catfile($self->optimised_directory(), 'contigs.fasta'), File::Spec->catfile($self->optimised_directory(), 'contigs.fa'));
   system("touch ". File::Spec->catfile($self->optimised_directory(), '_iva_optimise_parameters_done'));

--- a/modules/VertRes/Utils/Assemblers/iva.pm
+++ b/modules/VertRes/Utils/Assemblers/iva.pm
@@ -87,13 +87,9 @@ sub optimise_parameters
     "--seed_ext_min_ratio", (defined($self->{iva_seed_ext_min_ratio})) ? $self->{iva_seed_ext_min_ratio} : 2, 
     "--ext_min_cov",        (defined($self->{iva_ext_min_cov}))        ? $self->{iva_ext_min_cov}        : 5,
     "--ext_min_ratio",      (defined($self->{iva_ext_min_ratio}))      ? $self->{iva_ext_min_ratio}      : 2,
-  ));
-  
-  # insert size 
-  my $insert_size_opt = join(' ', ( "--max_insert", (defined($self->{iva_insert_size}))   ? $self->{iva_insert_size}   : 500) );
-  
-  # strand bias opt
-  my $strand_bias_opt = join(' ', ("--strand_bias", (defined($self->{iva_strand_bias}))   ? $self->{iva_strand_bias}   : 0) );
+    "--max_insert",         (defined($self->{iva_insert_size}))        ? $self->{iva_insert_size}        : 800,
+    "--strand_bias",        (defined($self->{iva_strand_bias}))        ? $self->{iva_strand_bias}        : 0,
+  ));  
   
   `$self->{optimiser_exec} $extension_opts $trimming_opts --fr $self->{files_str} --threads $num_threads iva_assembly`;
   File::Copy::move(File::Spec->catfile($self->optimised_directory(), 'contigs.fasta'), File::Spec->catfile($self->optimised_directory(), 'contigs.fa'));

--- a/modules/VertRes/Utils/Assemblers/iva.pm
+++ b/modules/VertRes/Utils/Assemblers/iva.pm
@@ -89,11 +89,11 @@ sub optimise_parameters
     "--ext_min_ratio",      (defined($self->{iva_ext_min_ratio}))      ? $self->{iva_ext_min_ratio}      : 2,
   ));
   
-  # insert size
-  my $insert_size_opt = join(' ', ("--max_insert", (defined($self->{iva_insert_size}))   ? $self->{iva_insert_size}   : 500);
+  # insert size 
+  my $insert_size_opt = join(' ', ( "--max_insert", (defined($self->{iva_insert_size}))   ? $self->{iva_insert_size}   : 500) );
   
   # strand bias opt
-  my $strand_bias_opt = join(' ', ("--strand_bias", (defined($self->{iva_strand_bias}))   ? $self->{iva_strand_bias}   : 0);
+  my $strand_bias_opt = join(' ', ("--strand_bias", (defined($self->{iva_strand_bias}))   ? $self->{iva_strand_bias}   : 0) );
   
   `$self->{optimiser_exec} $extension_opts $trimming_opts --fr $self->{files_str} --threads $num_threads iva_assembly`;
   File::Copy::move(File::Spec->catfile($self->optimised_directory(), 'contigs.fasta'), File::Spec->catfile($self->optimised_directory(), 'contigs.fa'));


### PR DESCRIPTION
This PR:

1) Adds an iva_qc step when creating the optimise_parameters.pl script if the iva_qc flag is set. 
2) Adds the extra options for iva (insert size and strand bias)