### PR TITLE
Run iva_qc inside the assembly directory and prepend prefix to done file

### DIFF
--- a/modules/VertRes/Pipelines/Assembly.pm
+++ b/modules/VertRes/Pipelines/Assembly.pm
@@ -430,9 +430,10 @@ if(defined($self->{iva_qc}) && $self->{iva_qc} && defined(qq[$self->{kraken_db}]
     			'reverse_reads'       => qq[$tmp_directory].'/reverse.fastq',
     			'assembly'			  => \$assembler->optimised_assembly_file_path(),
     			'iva_qc_exec'         => qq[$self->{iva_qc_exec}],
+    			'working_directory'	  => qq[$tmp_directory/$self->{assembler}_assembly], #run iva_qc inside assembly directory. eventually all files will be in a directory like iva_assembly inside lane directory
     			);
     \$iva_qc->run();
-    system('touch $output_directory/_iva_qc_done');
+    system('touch $output_directory/$self->{prefix}$self->{assembler}_iva_qc_done'); #The prefix in the config file is not always the name of assembler, so we append assembler name
 }
 
 


### PR DESCRIPTION
This PR changes two lines in the assembly pipeline to:

1) Run iva_qc inside the assembly directory
2) Prepend the prefix (from config file) and the name of the assembler to the iva_qc_done file in the lane directory. This is the same as with the rest of the "done" files in the lane directory.