### PR TITLE
Update Assembly.pm

### DIFF
--- a/modules/VertRes/Pipelines/Assembly.pm
+++ b/modules/VertRes/Pipelines/Assembly.pm
@@ -357,7 +357,9 @@ use Bio::AssemblyImprovement::Util::FastqTools;
 use Bio::AssemblyImprovement::Util::OrderContigsByLength;
 use Bio::AssemblyImprovement::IvaQC::Main;
 
-my \$assembly_pipeline = VertRes::Pipelines::Assembly->new();
+my \$assembly_pipeline = VertRes::Pipelines::Assembly->new(
+  assembler => "$self->{assembler}"
+);
 system("rm -rf $self->{assembler}_assembly_*");
 
 remove_tree(qq[$tmp_directory]) if(-d qq[$tmp_directory]);


### PR DESCRIPTION
Added missing assembler name when creating an instance of VertRes::Pipelines::Assembly (line 360).