### PR TITLE
Update Assembly.pm

### DIFF
--- a/modules/VertRes/Pipelines/Assembly.pm
+++ b/modules/VertRes/Pipelines/Assembly.pm
@@ -278,7 +278,7 @@ sub mapping_and_generate_stats
 
   system("touch \$directory/$self->{prefix}$self->{assembler}_${action_name_suffix}_done");
 
-  system("touch $self->{prefix}$self->{assembler}_${action_name_suffix}_done");
+  system("touch $output_directory/$self->{prefix}$self->{assembler}_${action_name_suffix}_done");
   exit;
                 };
   close $scriptfh;


### PR DESCRIPTION
At the moment, the file _velvet_map_back_done is created in the current working directory, which may be different from the lane path.
To be consistent with other actions,  _velvet_map_back_done files should be created in the same folder where other _done files are created (viz. in folder path held in $output_directory variable). 
