### PR TITLE
nds circularise option in pacbio assembly pipeline

### DIFF
--- a/modules/VertRes/Pipelines/PacbioAssembly.pm
+++ b/modules/VertRes/Pipelines/PacbioAssembly.pm
@@ -128,6 +128,7 @@ sub pacbio_assembly {
       open(my $scriptfh, '>', $script_name) or $self->throw("Couldn't write to temp script $script_name: $!");
       print $scriptfh qq{
   use strict;
+  use Bio::AssemblyImprovement::Circlator::Main;
   system("rm -rf $output_dir");
   system("pacbio_assemble_smrtanalysis --no_bsub --target_coverage $target_coverage $genome_size_estimate $output_dir $files");
   die "No assembly produced\n" unless( -e qq[$output_dir/assembly.fasta]);
@@ -151,7 +152,7 @@ sub pacbio_assembly {
   {
   	my \$circlator = Bio::AssemblyImprovement::Circlator::Main->new(
     			'assembly'			  => qq[$output_dir/contigs.fa],
-    			'corrected_reads'     => qq[$self->{lane_path}].'/'.$lane_name.'.corrected.fastq.gz',
+    			'corrected_reads'     => qq[$self->{lane_path}].'/$lane_name.corrected.fastq.gz',
     			'circlator_exec'      => qq[$self->{circlator_exec}],
     			'working_directory'	  => qq[$output_dir],
     			);

--- a/modules/VertRes/Pipelines/PacbioAssembly.pm
+++ b/modules/VertRes/Pipelines/PacbioAssembly.pm
@@ -162,14 +162,14 @@ sub pacbio_assembly {
     # If circlator was succesful, run quiver
     my \$circlator_final_file = qq[$output_dir/circularised/circlator.final.fasta];
     
-    if(-e $circlator_final_file]) {
+    if(-e $circlator_final_file) {
   		# run quiver
-  		my $quiver = Bio::AssemblyImprovement::Quiver::Main->new(
+  		my \$quiver = Bio::AssemblyImprovement::Quiver::Main->new(
     			'reference'      	  => \$circlator_final_file,
     			'bax_files'           => qq[$output_dir/*.bax.h5],
     			'working_directory'   => qq[$output_dir/circularised],	
     			);
-    	$quiver->run();
+    	\$quiver->run();
     	
     	my \$quiver_final_file = qq[$output_dir/circularised/quiver/circlator.final.fasta];
     	


### PR DESCRIPTION
This PR has the following changes to the pacbio assembly pipeline:

1) Accepts a circularise option from config files
2) Runs circlator and quiver
3) Does some renaming + symlinking of files to differentiate the original hgap assembly from the assembly that has been circularised
4) Runs assembly stats on the new circularised assembly
5) Increments pipeline version to 7
6) Touches done or failed files depending on the success of circlator and quiver
