### PR TITLE
nds pacbio assembly pipeline

### DIFF
--- a/modules/VertRes/Pipelines/PacbioAssembly.pm
+++ b/modules/VertRes/Pipelines/PacbioAssembly.pm
@@ -123,9 +123,9 @@ sub pacbio_assembly {
     my $queue = $self->{queue}|| "normal";
     my $pipeline_version = $self->{pipeline_version} || '7.0';
     my $target_coverage = $self->{target_coverage} || 30;
-    my $contigs_base_name = $self->generate_contig_base_name();
     my $umask    = $self->umask_str;
     my $lane_name = $self->{vrlane}->name;
+    my $contigs_base_name = $self->generate_contig_base_name($lane_name);
     
     my $script_name = $self->{fsu}->catfile($lane_path, $self->{prefix}."pacbio_assembly.pl");
     open(my $scriptfh, '>', $script_name) or $self->throw("Couldn't write to temp script $script_name: $!");
@@ -136,19 +136,23 @@ sub pacbio_assembly {
   use Bio::AssemblyImprovement::PrepareForSubmission::RenameContigs;
   $umask
 
+  # ~~~~~ Basic HGAP assembly ~~~~~~
   system("rm -rf $output_dir");
   system("pacbio_assemble_smrtanalysis --no_bsub --target_coverage $target_coverage $genome_size_estimate $output_dir $files");
-  die "No assembly produced\n" unless( -e qq[$output_dir/assembly.fasta]);
-  
+  die "No assembly produced\n" unless( -e qq[$output_dir/assembly.fasta]);  
   system("mv $output_dir/assembly.fasta $output_dir/contigs.fa");
-  system("sed -i.bak -e 's/|/_/' $output_dir/contigs.fa");  
+  system("sed -i -e 's/|quiver\\\$//' $output_dir/contigs.fa"); # remove the |quiver from end of contig names
   system("mv $output_dir/All_output/data/aligned_reads.bam $output_dir/contigs.mapped.sorted.bam");
   system("mv $output_dir/All_output/data/corrected.fastq $self->{lane_path}/$lane_name.corrected.fastq");
-  system("gzip -f -9 $self->{lane_path}/$lane_name.corrected.fastq");
+  system("gzip -f -9 $self->{lane_path}/$lane_name.corrected.fastq"); 
   system("rm -rf $output_dir/All_output/");
   
-  # Run circlator and quiver if needed
+  # ~~~~~~ Circlator ~~~~~~~
   if(defined($self->{circularise}) && $self->{circularise} == 1) {
+        # rename contigs here so that circlator logs have final contig names
+	Bio::AssemblyImprovement::PrepareForSubmission::RenameContigs->new(
+                                        input_assembly => qq[$output_dir/contigs.fa],
+                                        base_contig_name => qq[$contigs_base_name])->run();
   
   	my \$circlator = Bio::AssemblyImprovement::Circlator::Main->new(
     			'assembly'	      => qq[$output_dir/contigs.fa],
@@ -156,14 +160,14 @@ sub pacbio_assembly {
     			'circlator_exec'      => qq[$self->{circlator_exec}],
     			'working_directory'   => qq[$output_dir],
     			);
-    \$circlator->run();
-    my \$circlator_final_file = qq[$output_dir/circularised/circlator.final.fasta];
+       \$circlator->run();
+       my \$circlator_final_file = qq[$output_dir/circularised/circlator.final.fasta];
     
-    # If circlator was succesful, run quiver
+    # ~~~~~~ Quiver ~~~~~~~~~~
     if(-e \$circlator_final_file) {
-
-  		my \$quiver = Bio::AssemblyImprovement::Quiver::Main->new(
-    			'reference'      	  => \$circlator_final_file,
+	system("touch $self->{prefix}circularisation_done");
+        my \$quiver = Bio::AssemblyImprovement::Quiver::Main->new(
+    			'reference'           => \$circlator_final_file,
     			'bax_files'           => qq[$self->{lane_path}].'/*.bax.h5',
     			'working_directory'   => qq[$output_dir/circularised],	
 			'quiver_exec'         => qq[$self->{quiver_exec}],
@@ -174,32 +178,37 @@ sub pacbio_assembly {
     	my \$quiver_bam_file = qq[$output_dir/circularised/quiver/quiver.aligned_reads.bam];
     	my \$quiver_bai_file = qq[$output_dir/circularised/quiver/quiver.aligned_reads.bam.bai];
     	
-    	
     	if(-e \$quiver_final_file){
-
+		system("touch $self->{prefix}quiver_done");
     		system(qq[mv \$quiver_final_file $output_dir/circularised/quiver/hgap.circlator.quiver.contigs.fa]); # rename final assembly
-                system("sed -i.bak -e 's/|quiver$//' $output_dir/contigs.fa"); # remove the |quiver
+                system("sed -i -e 's/|quiver\\\$//' $output_dir/circularised/quiver/hgap.circlator.quiver.contigs.fa"); # remove the |quiver from ends of contig names
     		system(qq[mv $output_dir/contigs.fa $output_dir/hgap.contigs.fa]); # rename original hgap assembly
 		system(qq[mv \$quiver_bam_file $output_dir/contigs.mapped.sorted.bam]); # copy over bam file
-		# create a symlink called contigs.fa pointing to the new quiverised fasta file
+		system(qq[rm -f \$quiver_bai_file]); # clean this file up - we generate our own later. Should we use it?
+		# create a symlink called contigs.fa pointing to the new quiverised fasta file so that *find scripts continue to work
     		system(qq[ln -s $output_dir/circularised/quiver/hgap.circlator.quiver.contigs.fa $output_dir/contigs.fa]);
-  	        # The update db process will only be done after this, hence the assembled flag for lanes will be set only after circlator and quiver has been run (if applicable)
     	}#end quiver success   
     }#end circlator success
   }#end if circularised
   
-  # run assembly stats and bamcheck on assembly
+  # ~~~~~~~ Bamcheck, assemblystats, cleanup ~~~~~~~~~
   system("samtools index $output_dir/contigs.mapped.sorted.bam");
   system("bamcheck -c 1,20000,5 -r $output_dir/contigs.fa $output_dir/contigs.mapped.sorted.bam > $output_dir/contigs.mapped.sorted.bam.bc");
   system("assembly_stats $output_dir/contigs.fa  > $output_dir/contigs.fa.stats");
-  # rename contigs to keep in line with what we do for illumina assemblies
-  Bio::AssemblyImprovement::PrepareForSubmission::RenameContigs->new(
-  					input_assembly => $output_dir/contigs.fa,
+  system("rm -f $output_dir/contigs.mapped.sorted.bam"); # delete BAM and BAI files to save space
+  system("rm -f $output_dir/contigs.mapped.sorted.bam.bai");
+  
+  if(not defined($self->{circularise}) || $self->{circularise} == 0) {
+	# If circularisation has not been done, rename here (i.e. after bamcheck so that there are no problems with contig
+	# names not matching the names in the BAM file generated by hgap)
+  	  Bio::AssemblyImprovement::PrepareForSubmission::RenameContigs->new(
+  					input_assembly => qq[$output_dir/contigs.fa],
   					base_contig_name => qq[$contigs_base_name])->run();    		      
+  }
   
   # touch done file and pipeline_version_7
   system("touch $output_dir/pipeline_version_$pipeline_version");
-  system("touch $self->{prefix}pacbio_assembly_done");
+  system("touch $self->{prefix}assembly_done");
   exit;
   };
   close $scriptfh;
@@ -216,7 +225,7 @@ sub pacbio_assembly {
 
  Title   : generate_contig_base_name
  Usage   : 
- Function: Generates a name that can be used as a prefix for contig names in assembly (usually the lane's accession number)
+ Function: Generates a name that can be used as a prefix for contig names in assembly (usually the lane's accession number + lane name)
  Returns : base name
  Args    : lane path
 
@@ -225,7 +234,6 @@ sub pacbio_assembly {
 sub generate_contig_base_name
 {
   my ($self, $lane_name) = @_;
-  $self->{vrtrack} = VRTrack::VRTrack->new($self->{db}) or $self->throw("Could not connect to the database\n");
   my $vrlane  = VRTrack::Lane->new_by_name($self->{vrtrack}, $lane_name) or $self->throw("No such lane in the DB: [".$lane_name."]");
   if(defined($vrlane->acc())) {
       return join('.',($vrlane->acc(),$lane_name));


### PR DESCRIPTION
This PR contains the latest changed to the pacbio assembly pipeline. It adds a stage to rename contigs (in keeping with what we do for Illumina data) at appropriate stages in the pipeline so that logs and info files all have the updates contig names. It also has a few bug fixes and steps to clean up BAM/BAI files to save space.