### PR TITLE
Remove HDF5 files from PacBio pipelines

### DIFF
--- a/modules/VertRes/Pipelines/Import_iRODS_cram.pm
+++ b/modules/VertRes/Pipelines/Import_iRODS_cram.pm
@@ -524,7 +524,6 @@ sub update_db_master
         $vrfile->update();
     }
 
-
     # Update the lane stats
     my $read_len=0;
     my $raw_reads=0;
@@ -538,7 +537,6 @@ sub update_db_master
     $vrlane->raw_reads($raw_reads);
     $vrlane->raw_bases($raw_bases);
     $vrlane->read_len($read_len);
-
 
     # Finally, change the import status of the lane, so that it will not be picked up again
     #   by the run-pipeline script.

--- a/modules/VertRes/Pipelines/Import_iRODS_pacbio.pm
+++ b/modules/VertRes/Pipelines/Import_iRODS_pacbio.pm
@@ -245,7 +245,7 @@ sub convert_bax_to_fastq {
 		{
 			remove_tree('bax2fastq');
 		}
-		
+
         my $fastqcheck = VertRes::Wrapper::fastqcheck->new();
         $fastqcheck->run( $fastq, $fastq . '.fastqcheck' );
     }
@@ -379,12 +379,19 @@ sub update_db {
 	# Add the BAMs and FASTQ files to the file table	
     for my $file ((@{$self->_output_bam_filenames()},@{$self->_output_fastq_filenames()}))
     {
-        my $vrfile = $vrlane->get_file_by_name($file);
-        if ( !$vrfile ) { $self->throw("FIXME: no such file [$file] for the lane [$lane_path]."); }
+		my($filename_base, $dirs, $suffix) = fileparse($file);
+		
+	    # The file may be absent from the database
+	    my $vrfile = $vrlane->get_file_by_name($filename_base);
+	    if ( !$vrfile ) 
+	    { 
+	        $vrfile = $vrlane->add_file($filename_base); 
+	        $vrfile->hierarchy_name($filename_base);
+	    }
         $vrfile->is_processed('import',1);
         $vrfile->update();
     }
-	
+
 	# Delete the h5 files
 	for my $file (@{$self->_h5_filenames()})
 	{

--- a/modules/VertRes/Pipelines/Import_iRODS_pacbio.pm
+++ b/modules/VertRes/Pipelines/Import_iRODS_pacbio.pm
@@ -379,7 +379,7 @@ sub update_db {
 	# Add the BAMs and FASTQ files to the file table	
     for my $file ((@{$self->_output_bam_filenames()},@{$self->_output_fastq_filenames()}))
     {
-        my $vrsfile = $vrlane->get_file_by_name($file);
+        my $vrfile = $vrlane->get_file_by_name($file);
         if ( !$vrfile ) { $self->throw("FIXME: no such file [$file] for the lane [$lane_path]."); }
         $vrfile->is_processed('import',1);
         $vrfile->update();
@@ -399,7 +399,7 @@ sub update_db {
         next if ( $ifile =~ /\.bam/ );
         my ( $filename, $dirs, $suffix ) = fileparse($ifile);
 
-        if ( $ifile =~ m!^/seq/! ) ) { 
+        if ( $ifile =~ m!^/seq/! ) { 
 			my $vrfile = $vrlane->get_file_by_name($ifile);
 	        $vrfile->is_latest(0);
 	        $vrfile->update();

--- a/modules/VertRes/Pipelines/Import_iRODS_pacbio.pm
+++ b/modules/VertRes/Pipelines/Import_iRODS_pacbio.pm
@@ -380,10 +380,11 @@ sub update_db {
     for my $file ((@{$self->_output_bam_filenames()},@{$self->_output_fastq_filenames()}))
     {
 		my($filename_base, $dirs, $suffix) = fileparse($file);
+		my $full_filename = $lane_path.'/'.$filename_base;
 		
-		Utils::CMD(qq[md5sum $file > $file.md5]);
-		my ($md5) = Utils::CMD(qq[awk '{printf "%s",\$1}' $file]);
-		Utils::CMD(qq[rm -rf $file.md5]);
+		Utils::CMD(qq[md5sum $full_filename > $full_filename.md5]);
+		my ($md5) = Utils::CMD(qq[awk '{printf "%s",\$1}' $full_filename]);
+		Utils::CMD(qq[rm -rf $full_filename.md5]);
 		
 	    # The file may be absent from the database
 	    my $vrfile = $vrlane->get_file_by_name($filename_base);

--- a/modules/VertRes/Pipelines/Import_iRODS_pacbio.pm
+++ b/modules/VertRes/Pipelines/Import_iRODS_pacbio.pm
@@ -381,6 +381,10 @@ sub update_db {
     {
 		my($filename_base, $dirs, $suffix) = fileparse($file);
 		
+		Utils::CMD(qq[md5sum $file > $file.md5]);
+		my ($md5) = Utils::CMD(qq[awk '{printf "%s",\$1}' $file]);
+		Utils::CMD(qq[rm -rf $file.md5]);
+		
 	    # The file may be absent from the database
 	    my $vrfile = $vrlane->get_file_by_name($filename_base);
 	    if ( !$vrfile ) 
@@ -388,6 +392,7 @@ sub update_db {
 	        $vrfile = $vrlane->add_file($filename_base); 
 	        $vrfile->hierarchy_name($filename_base);
 	    }
+		$vrfile->md5($md5);
         $vrfile->is_processed('import',1);
         $vrfile->update();
     }

--- a/modules/VertRes/Pipelines/Import_iRODS_pacbio.pm
+++ b/modules/VertRes/Pipelines/Import_iRODS_pacbio.pm
@@ -408,9 +408,10 @@ sub update_db {
 	# Delete the h5 files
 	for my $file (@{$self->_h5_filenames()})
 	{
-		if(defined($file) && -e $file )
+		my $full_file_path =  $lane_path.'/'.$file;
+		if(defined($file) && -e $full_file_path )
 		{
-			unlink( $file );
+			unlink( $full_file_path );
 		}
 	}
 	

--- a/modules/VertRes/Pipelines/Import_iRODS_pacbio.pm
+++ b/modules/VertRes/Pipelines/Import_iRODS_pacbio.pm
@@ -386,11 +386,6 @@ sub update_db {
 		my($filename_base, $dirs, $suffix) = fileparse($file);
 		my $full_filename = $lane_path.'/'.$filename_base;
 		
-		if(! -e $full_filename.'.md5')
-		{
-			Utils::CMD(qq[md5sum $full_filename > $full_filename.md5]);
-		}
-		my ($md5) = Utils::CMD(qq[awk '{printf "%s",\$1}' $full_filename.md5]);
 
 	    # The file may be absent from the database
 	    my $vrfile = $vrlane->get_file_by_name($filename_base);
@@ -399,7 +394,16 @@ sub update_db {
 	        $vrfile = $vrlane->add_file($filename_base); 
 	        $vrfile->hierarchy_name($filename_base);
 	    }
-		$vrfile->md5($md5);
+		
+		if(! defined($vrfile->md5() ))
+		{
+		    if(! -e $full_filename.'.md5')
+		    {
+		    	Utils::CMD(qq[md5sum $full_filename > $full_filename.md5]);
+		    }
+		    my ($md5) = Utils::CMD(qq[awk '{printf "%s",\$1}' $full_filename.md5]);
+			$vrfile->md5($md5);
+		}
         $vrfile->is_processed('import',1);
         $vrfile->update();
 		Utils::CMD(qq[rm -rf $full_filename.md5]);
@@ -412,6 +416,12 @@ sub update_db {
 		if(defined($file) && -e $full_file_path )
 		{
 			unlink( $full_file_path );
+		}
+		
+		my $full_file_path_md5 =  $lane_path.'/'.$file.'.md5';
+		if(defined($file) && -e $full_file_path_md5 )
+		{
+			unlink( $full_file_path_md5 );
 		}
 	}
 	

--- a/modules/VertRes/Pipelines/Import_iRODS_pacbio.pm
+++ b/modules/VertRes/Pipelines/Import_iRODS_pacbio.pm
@@ -165,6 +165,17 @@ sub _bas_h5_filenames {
     return \@output_files;
 }
 
+sub _h5_filenames {
+    my ($self) = @_;
+    my @output_files;
+    for my $file ( @{ $self->{files} } ) {
+        next unless ( $file =~ /\.h5$/ );
+        my ( $filename, $dirs, $suffix ) = fileparse($file);
+        push( @output_files, $filename );
+    }
+    return \@output_files;
+}
+
 sub convert_to_fastq {
     my ( $self, $lane_path, $lock_file ) = @_;
     my $memory_in_mb = 2500;
@@ -346,6 +357,15 @@ sub update_db {
             unlink( $self->{fsu}->catfile( $lane_path, $prefix . $file . '.' . $suffix ) );
         }
     }
+	
+	# Delete the h5 files
+	for my $file (@{$self->_h5_filenames()})
+	{
+		if(defined($file) && -e $file )
+		{
+			unlink( $file );
+		}
+	}
 
     my $vrtrack = VRTrack::VRTrack->new( $$self{db} ) or $self->throw("Could not connect to the database\n");
     my $vrlane = VRTrack::Lane->new_by_name( $vrtrack, $$self{lane} ) or $self->throw("No such lane in the DB: [$$self{lane}]\n");

--- a/modules/VertRes/Pipelines/PacbioAssembly.pm
+++ b/modules/VertRes/Pipelines/PacbioAssembly.pm
@@ -190,6 +190,8 @@ sub hgap_assembly {
     my $contigs_base_name = $self->generate_contig_base_name($lane_name);
 	my $correction_output_dir = $output_dir.'/correction';
 	my $uncorrected_fastq = $self->generate_fastq_filename_from_subreads_filename($self->hgap_assembly_requires()->[0]);
+	my $corrected_reads = $self->{lane_path}."/$lane_name.corrected.fasta.gz";
+	
     my $script_name = $self->{fsu}->catfile($lane_path, $self->{prefix}."hgap_assembly.pl");
     open(my $scriptfh, '>', $script_name) or $self->throw("Couldn't write to temp script $script_name: $!");
     print $scriptfh qq{
@@ -214,14 +216,8 @@ sub hgap_assembly {
                                         input_assembly => qq[$output_dir/contigs.fa],
                                         base_contig_name => qq[$contigs_base_name])->run();
   
-  	my \$circlator = Bio::AssemblyImprovement::Circlator::Main->new(
-    			'assembly'	      => qq[$output_dir/contigs.fa],
-    			'corrected_reads'     => qq[$self->{lane_path}].'/$lane_name.corrected.fasta.gz',
-    			'circlator_exec'      => qq[$self->{circlator_exec}],
-    			'working_directory'   => qq[$output_dir],
-    			);
-       \$circlator->run();
-       my \$circlator_final_file = qq[$output_dir/circularised/circlator.final.fasta];
+       system(qq[$self->{circlator_exec} --assembler canu $output_dir/contigs.fa $corrected_reads $output_dir/circularised]);
+       my \$circlator_final_file = qq[$output_dir/circularised/06.fixstart.fasta];
     
 	# ~~~~~~ Quiver/Resequencing ~~~~~~~~~~
 	if(-e \$circlator_final_file) {

--- a/modules/VertRes/Pipelines/PacbioAssembly.pm
+++ b/modules/VertRes/Pipelines/PacbioAssembly.pm
@@ -58,12 +58,6 @@ use Bio::AssemblyImprovement::PrepareForSubmission::RenameContigs;
 
 our $actions = [
     {
-        name     => 'pacbio_assembly',
-        action   => \&pacbio_assembly,
-        requires => \&pacbio_assembly_requires,
-        provides => \&pacbio_assembly_provides
-    },
-    {
         name     => 'correct_reads',
         action   => \&correct_reads,
         requires => \&correct_reads_requires,
@@ -94,7 +88,6 @@ our %options = ( bsub_opts => '' ,
 				 samtools_htslib_exec => '/software/pathogen/external/apps/usr/bin/samtools-1.6',
 				 bwa_mem_exec => '/software/pathogen/external/apps/usr/bin/bwa-0.7.10',
 				 circlator_exec => '/software/pathogen/external/bin/circlator', # move to config files?
-				 quiver_exec => '/software/pathogen/internal/prod/bin/pacbio_smrtanalysis',
 				 minimap2_exec => '/software/pathogen/external/apps/usr/bin/minimap2',
 				 hgap_version_str => 'hgap_4_0',
 				 );
@@ -112,142 +105,6 @@ sub new {
     return $self;
 }
 
-sub pacbio_assembly_provides {
-    my ($self) = @_;
-    return [$self->{lane_path}."/pacbio_assembly/contigs.fa", $self->{lane_path}."/".$self->{prefix}."assembly_done"];
-}
-
-sub pacbio_assembly_requires {
-    my ($self) = @_;
-    my $file_regex = $self->{lane_path}."/".'*.bax.h5';
-    my @files = glob( $file_regex);
-    die 'no files to assemble' if(@files == 0);
-    
-    return \@files;
-}
-
-=head2 pacbio_assembly
-
- Title   : pacbio_assembly
- Usage   : $obj->pacbio('/path/to/lane', 'lock_filename');
- Function: Take an assembly from the assembly pipeline and automatically pacbio it.
- Returns : $VertRes::Pipeline::Yes or No, depending on if the action completed.
- Args    : lane path, name of lock file to use
-
-=cut
-
-sub pacbio_assembly {
-    my ($self, $lane_path, $action_lock) = @_;
-    
-    my $memory_in_mb = $self->{memory} || 64000;
-    my $threads = $self->{threads} || 12;
-    my $genome_size_estimate = $self->{genome_size} || 4000000;
-    my $files = join(' ', @{$self->pacbio_assembly_requires()});
-    my $output_dir= $self->{lane_path}."/pacbio_assembly";
-    my $queue = $self->{queue}|| "normal";
-    my $pipeline_version = $self->{pipeline_version} || '7.0';
-    my $target_coverage = $self->{target_coverage} || 30;
-    my $umask    = $self->umask_str;
-    my $lane_name = $self->{vrlane}->name;
-    my $contigs_base_name = $self->generate_contig_base_name($lane_name);
-    
-    my $script_name = $self->{fsu}->catfile($lane_path, $self->{prefix}."assembly.pl");
-    open(my $scriptfh, '>', $script_name) or $self->throw("Couldn't write to temp script $script_name: $!");
-    print $scriptfh qq{
-  use strict;
-  use Bio::AssemblyImprovement::Circlator::Main;
-  use Bio::AssemblyImprovement::Quiver::Main;
-  use Bio::AssemblyImprovement::PrepareForSubmission::RenameContigs;
-  $umask
-
-  # ~~~~~ Basic HGAP assembly ~~~~~~
-  system("rm -rf $output_dir");
-  system("pacbio_assemble_smrtanalysis --no_bsub --target_coverage $target_coverage $genome_size_estimate $output_dir $files");
-  die "No assembly produced\n" unless( -e qq[$output_dir/assembly.fasta]);  
-  system("mv $output_dir/assembly.fasta $output_dir/contigs.fa");
-  system("sed -i -e 's/|quiver\\\$//' $output_dir/contigs.fa"); # remove the |quiver from end of contig names
-  system("mv $output_dir/All_output/data/aligned_reads.bam $output_dir/contigs.mapped.sorted.bam");
-  
-  if(! -e "$self->{lane_path}/$lane_name.corrected.fastq")
-  {
-    system("mv $output_dir/All_output/data/corrected.fastq $self->{lane_path}/$lane_name.corrected.fastq");
-  }
-  system("rm -rf $output_dir/All_output");
-  system("gzip -f -9 $self->{lane_path}/$lane_name.corrected.fastq"); 
-  
-  # ~~~~~~ Circlator ~~~~~~~
-  if(defined($self->{circularise}) && $self->{circularise} == 1) {
-        # rename contigs here so that circlator logs have final contig names
-	Bio::AssemblyImprovement::PrepareForSubmission::RenameContigs->new(
-                                        input_assembly => qq[$output_dir/contigs.fa],
-                                        base_contig_name => qq[$contigs_base_name])->run();
-  
-  	my \$circlator = Bio::AssemblyImprovement::Circlator::Main->new(
-    			'assembly'	      => qq[$output_dir/contigs.fa],
-    			'corrected_reads'     => qq[$self->{lane_path}].'/$lane_name.corrected.fastq.gz',
-    			'circlator_exec'      => qq[$self->{circlator_exec}],
-    			'working_directory'   => qq[$output_dir],
-    			);
-       \$circlator->run();
-       my \$circlator_final_file = qq[$output_dir/circularised/circlator.final.fasta];
-    
-    # ~~~~~~ Quiver ~~~~~~~~~~
-    if(-e \$circlator_final_file) {
-	system("touch $self->{prefix}circularisation_done");
-        my \$quiver = Bio::AssemblyImprovement::Quiver::Main->new(
-    			'reference'           => \$circlator_final_file,
-    			'bax_files'           => qq[$self->{lane_path}].'/*.bax.h5',
-    			'working_directory'   => qq[$output_dir/circularised],	
-			'quiver_exec'         => qq[$self->{quiver_exec}],
-    			);
-    	\$quiver->run();
-    	
-    	my \$quiver_final_file = qq[$output_dir/circularised/quiver/quiver.final.fasta];
-    	my \$quiver_bam_file = qq[$output_dir/circularised/quiver/quiver.aligned_reads.bam];
-    	my \$quiver_bai_file = qq[$output_dir/circularised/quiver/quiver.aligned_reads.bam.bai];
-    	
-    	if(-e \$quiver_final_file){
-		system("touch $self->{prefix}quiver_done");
-    		system(qq[mv \$quiver_final_file $output_dir/circularised/quiver/hgap.circlator.quiver.contigs.fa]); # rename final assembly
-                system("sed -i -e 's/|quiver\\\$//' $output_dir/circularised/quiver/hgap.circlator.quiver.contigs.fa"); # remove the |quiver from ends of contig names
-    		system(qq[mv $output_dir/contigs.fa $output_dir/hgap.contigs.fa]); # rename original hgap assembly
-		system(qq[mv \$quiver_bam_file $output_dir/contigs.mapped.sorted.bam]); # copy over bam file
-		system(qq[rm -f \$quiver_bai_file]); # clean this file up - we generate our own later. Should we use it?
-		# create a symlink called contigs.fa pointing to the new quiverised fasta file so that *find scripts continue to work
-    		system(qq[ln -s $output_dir/circularised/quiver/hgap.circlator.quiver.contigs.fa $output_dir/contigs.fa]);
-    	}#end quiver success   
-    }#end circlator success
-  }#end if circularised
-  
-  # ~~~~~~~ Bamcheck, assemblystats, cleanup ~~~~~~~~~
-  system("samtools index $output_dir/contigs.mapped.sorted.bam");
-  system("bamcheck -c 1,20000,5 -r $output_dir/contigs.fa $output_dir/contigs.mapped.sorted.bam > $output_dir/contigs.mapped.sorted.bam.bc");
-  system("assembly_stats $output_dir/contigs.fa  > $output_dir/contigs.fa.stats");
-  system("rm -f $output_dir/contigs.mapped.sorted.bam"); # delete BAM and BAI files to save space
-  system("rm -f $output_dir/contigs.mapped.sorted.bam.bai");
-  
-  if(not defined($self->{circularise}) || $self->{circularise} == 0) {
-	# If circularisation has not been done, rename here (i.e. after bamcheck so that there are no problems with contig
-	# names not matching the names in the BAM file generated by hgap)
-  	  Bio::AssemblyImprovement::PrepareForSubmission::RenameContigs->new(
-  					input_assembly => qq[$output_dir/contigs.fa],
-  					base_contig_name => qq[$contigs_base_name])->run();    		      
-  }
-  
-  # touch done file and pipeline_version_7
-  system("touch $output_dir/pipeline_version_$pipeline_version");
-  system("touch $self->{prefix}assembly_done");
-  exit;
-  };
-  close $scriptfh;
- 
-  my $job_name = $self->{prefix}.'pacbio_assembly';
-      
-    $self->delete_bsub_files($lane_path, $job_name);
-    VertRes::LSF::run($action_lock, $lane_path, $job_name, {bsub_opts => "-n$threads -q $queue -M${memory_in_mb} -R 'select[mem>$memory_in_mb] rusage[mem=$memory_in_mb] span[hosts=1]'"}, qq{perl -w $script_name});
-
-    return $self->{No};
-}
 
 sub correct_reads_provides {
     my ($self) = @_;
@@ -522,7 +379,7 @@ sub generate_contig_base_name
 
 sub update_db_requires {
     my ($self, $lane_path) = @_;
-	my @all_assemblies = (@{$self->hgap_assembly_provides()}, @{$self->pacbio_assembly_provides()}, @{$self->modification_provides()});
+	my @all_assemblies = (@{$self->hgap_assembly_provides()}, @{$self->modification_provides()});
     return \@all_assemblies;
 }
 
@@ -576,7 +433,7 @@ sub update_db {
     
     my $prefix = $self->{prefix};
     # remove job files
-    foreach my $file (qw(pacbio_assembly hgap_assembly correct_reads modification)) 
+    foreach my $file (qw( hgap_assembly correct_reads modification)) 
       {
         foreach my $suffix (qw(o e pl)) 
         {


### PR DESCRIPTION
When h5 files are imported, delete them and only save the BAM files.
Assemblies only happen with HGAP 4.0 using the BAM files as input.