### PR TITLE
Rt643297 pacbio pipeline updates

### DIFF
--- a/modules/VertRes/Pipelines/PacbioAssembly.pm
+++ b/modules/VertRes/Pipelines/PacbioAssembly.pm
@@ -212,7 +212,11 @@ sub canu_assembly {
   system("rm -rf $canu_output_dir");
   system("canu -p canu -d $canu_output_dir genomeSize=${genome_size_estimate_kb}k maxMemory=${memory_in_gb}g maxThreads=${threads} -pacbio-corrected $corrected_reads");
   system("mkdir $output_dir");
-  system("mv $canu_output_dir/canu.unitigs.fasta $output_dir/contigs.fa");
+  system("mv $canu_output_dir/canu.contigs.fasta $output_dir/contigs.fa");
+  system("mv $canu_output_dir/canu.contigs.gfa $output_dir/contigs.gfa");
+  system("mv $canu_output_dir/canu.unitigs.fasta $output_dir/unitigs.fa");
+  system("mv $canu_output_dir/canu.unitigs.gfa $output_dir/unitigs.gfa");
+  system("mv $canu_output_dir/canu.unitigs.bed $output_dir/unitigs.bed");
   system("rm -rf $canu_output_dir");
   
   # ~~~~~~ Circlator ~~~~~~~

--- a/modules/VertRes/Pipelines/PacbioAssembly.pm
+++ b/modules/VertRes/Pipelines/PacbioAssembly.pm
@@ -213,10 +213,10 @@ sub canu_assembly {
   system("canu -p canu -d $canu_output_dir genomeSize=${genome_size_estimate_kb}k maxMemory=${memory_in_gb}g maxThreads=${threads} -pacbio-corrected $corrected_reads");
   system("mkdir $output_dir");
   system("mv $canu_output_dir/canu.contigs.fasta $output_dir/contigs.fa");
-  system("mv $canu_output_dir/canu.contigs.gfa $output_dir/contigs.gfa");
-  system("mv $canu_output_dir/canu.unitigs.fasta $output_dir/unitigs.fa");
-  system("mv $canu_output_dir/canu.unitigs.gfa $output_dir/unitigs.gfa");
-  system("mv $canu_output_dir/canu.unitigs.bed $output_dir/unitigs.bed");
+  system("mv $canu_output_dir/canu.contigs.gfa $output_dir/canu.contigs.gfa");
+  system("mv $canu_output_dir/canu.unitigs.fasta $output_dir/canu.unitigs.fa");
+  system("mv $canu_output_dir/canu.unitigs.gfa $output_dir/canu.unitigs.gfa");
+  system("mv $canu_output_dir/canu.unitigs.bed $output_dir/canu.unitigs.bed");
   system("rm -rf $canu_output_dir");
   
   # ~~~~~~ Circlator ~~~~~~~

--- a/modules/VertRes/Pipelines/PacbioAssembly.pm
+++ b/modules/VertRes/Pipelines/PacbioAssembly.pm
@@ -136,8 +136,8 @@ sub correct_reads {
 	my $threads = 4;
 	my $memory_in_gb = 10;
 	my $memory_in_mb = $memory_in_gb*1000;
-	# This can be hardcoded
-	my $genome_size_estimate_kb = 8000;
+	my $genome_size_estimate = $self->{genome_size} || 4500000;
+  my $genome_size_estimate_kb = $genome_size_estimate/1000;
 	my $correction_output_dir = $self->{lane_path}.'/tmp_correction';
 	
     open(my $scriptfh, '>', $script_name) or $self->throw("Couldn't write to temp script $script_name: $!");
@@ -182,8 +182,8 @@ sub canu_assembly {
     my $memory_in_mb = 30000;
 	my $memory_in_gb = $memory_in_mb/1000;
     my $threads = 8;
-    my $genome_size_estimate = 8000000;
-	my $genome_size_estimate_kb = $genome_size_estimate/1000;
+  my $genome_size_estimate = $self->{genome_size} || 4500000;
+  my $genome_size_estimate_kb = $genome_size_estimate/1000;
 	my $canu_output_dir = $self->{lane_path}.'/tmp_canu';
 
     my $files = join(' ', @{$self->get_subreads_bams()});
@@ -287,7 +287,7 @@ sub hgap_assembly {
     my $memory_in_mb = 40000;
 	my $memory_in_gb = $memory_in_mb/1000;
     my $threads = 12;
-    my $genome_size_estimate = $self->{genome_size} || 8000000;
+  my $genome_size_estimate = $self->{genome_size} || 4500000;
 	my $genome_size_estimate_kb = $genome_size_estimate/1000;
 
     my $files = join(' ', @{$self->get_subreads_bams()});

--- a/modules/VertRes/Pipelines/PacbioAssembly.pm
+++ b/modules/VertRes/Pipelines/PacbioAssembly.pm
@@ -222,7 +222,7 @@ sub canu_assembly {
                                         input_assembly => qq[$output_dir/contigs.fa],
                                         base_contig_name => qq[$contigs_base_name])->run();
   
-       system(qq[$self->{circlator_exec} --assembler canu $output_dir/contigs.fa $corrected_reads $output_dir/circularised]);
+       system(qq[$self->{circlator_exec} all --assembler canu $output_dir/contigs.fa $corrected_reads $output_dir/circularised]);
        my \$circlator_final_file = qq[$output_dir/circularised/06.fixstart.fasta];
     
 	# ~~~~~~ Quiver/Resequencing ~~~~~~~~~~
@@ -329,7 +329,7 @@ sub hgap_assembly {
                                         input_assembly => qq[$output_dir/contigs.fa],
                                         base_contig_name => qq[$contigs_base_name])->run();
   
-       system(qq[$self->{circlator_exec} --assembler canu $output_dir/contigs.fa $corrected_reads $output_dir/circularised]);
+       system(qq[$self->{circlator_exec} all --assembler canu $output_dir/contigs.fa $corrected_reads $output_dir/circularised]);
        my \$circlator_final_file = qq[$output_dir/circularised/06.fixstart.fasta];
     
 	# ~~~~~~ Quiver/Resequencing ~~~~~~~~~~

--- a/modules/VertRes/Pipelines/PacbioAssembly.pm
+++ b/modules/VertRes/Pipelines/PacbioAssembly.pm
@@ -217,6 +217,7 @@ sub canu_assembly {
   system("mv $canu_output_dir/canu.unitigs.fasta $output_dir/canu.unitigs.fa");
   system("mv $canu_output_dir/canu.unitigs.gfa $output_dir/canu.unitigs.gfa");
   system("mv $canu_output_dir/canu.unitigs.bed $output_dir/canu.unitigs.bed");
+  system("mv $canu_output_dir/canu.unassembled.fasta $output_dir/canu.unassembled.fa");
   system("rm -rf $canu_output_dir");
   
   # ~~~~~~ Circlator ~~~~~~~


### PR DESCRIPTION
Update pacbio default genome size to 4500kb
Remove hard coding of genome size from canu assembly
Keep canu .fasta (.fa), .bed and .gfa files 
Move canu.contigs.fa to contigs.fa instead of the unitigs