### PR TITLE
FSU database

### DIFF
--- a/modules/VertRes/Utils/FileSystem.pm
+++ b/modules/VertRes/Utils/FileSystem.pm
@@ -784,16 +784,11 @@ sub file_exists {
     
     if ($opts{wipe_out}) {
         if ($opts{recurse}) {
-            $file_exists_dbh->do(qq{DELETE FROM file_status WHERE path LIKE '$file/%'});
-            $file_exists_dbh->do(qq{DELETE FROM file_status WHERE path = '$file'});
+            $file_exists_dbh->do(qq{DELETE FROM file_status WHERE path LIKE ?}, undef, $file . '/%'});
+            $file_exists_dbh->do(qq{DELETE FROM file_status WHERE path = ?}, undef, $file);
         }
         else {
-            if ($opts{check_path}) {
-                $file_exists_dbh->do(qq{DELETE FROM file_status WHERE path = ?},undef,$file);
-            }
-            else {
-                $file_exists_dbh->do(qq{DELETE FROM file_status WHERE hash = ? AND path = ?},undef,$md5,$file);
-            }
+            $file_exists_dbh->do(qq{DELETE FROM file_status WHERE path = ?}, undef, $file);
         }
         if ( $$self{reconnect_db} )
         {
@@ -810,14 +805,8 @@ sub file_exists {
     
     # check the db
     unless ($opts{force_check}) {
-        if ($opts{check_path}) {
-            my $sql = qq{select * from `file_status` where `path` = ?};
-            my @row = $file_exists_dbh->selectrow_array($sql, undef, $file);
-        }
-        else {
-            my $sql = qq{select * from `file_status` where `hash` = ?};
-            my @row = $file_exists_dbh->selectrow_array($sql, undef, $md5);
-        }
+        my $sql = qq{select * from `file_status` where `path` = ?};
+        my @row = $file_exists_dbh->selectrow_array($sql, undef, $file);
         if (@row) {
             if ($row[2] && $row[2] == 1) {
                 if ( $$self{reconnect_db} )
@@ -843,9 +832,9 @@ sub file_exists {
     # check the disk
     my $exists = -e $file ? 1 : 0;
     
-    # store result in db
-    my $sql = qq{insert into `file_status` (hash,path,status) values (?,?,?) ON DUPLICATE KEY UPDATE `status`=?};
-    $file_exists_dbh->do($sql, undef, $md5, $file, $exists, $exists) || $self->throw($file_exists_dbh->errstr);
+    # if we got to this stage, the file isn't stored in the db. Do so now. If the hash already exists for whatever reason, reuse it.
+    my $sql = qq{insert into `file_status` (hash,path,status) values (?,?,?) ON DUPLICATE KEY UPDATE `path`=?, `status`=?};
+    $file_exists_dbh->do($sql, undef, $md5, $file, $exists, $file, $exists) || $self->throw($file_exists_dbh->errstr);
 
     if ( $$self{reconnect_db} )
     {

--- a/scripts/vrtracking_tool
+++ b/scripts/vrtracking_tool
@@ -485,7 +485,7 @@ while (<>) {
 
                             if ( $fsu->file_exists($filepath, check_path => 1) ) {
                                 unless ($test) {
-                                    if ($fsu->file_exists( $filepath, recurse => 1, wipe_out => 1, check_path => 1 ) != 0)
+                                    if ($fsu->file_exists( $filepath, recurse => 1, wipe_out => 1 ) != 0)
                                     {
                                         die "Unable to delete the directory $filepath from fsu database, error = $!\n";
                                     }
@@ -497,7 +497,7 @@ while (<>) {
                             unless ($test) { unlink $filepath or die "Unable to delete $filepath, error = $!\n" }
                             if ( $fsu->file_exists($filepath, check_path => 1) ) {
                                 unless ($test) {
-                                    if ($fsu->file_exists( $filepath, wipe_out => 1, check_path => 1 ) != 0)
+                                    if ($fsu->file_exists( $filepath, wipe_out => 1 ) != 0)
                                     {
                                         die "Unable to delete $filepath from fsu database, error = $!\n";
                                     }

--- a/scripts/vrtracking_tool
+++ b/scripts/vrtracking_tool
@@ -214,8 +214,7 @@ Examples:
 
 USAGE
 
-my $verbose = !$quiet
-$verbose ? Log::Log4perl->easy_init($INFO) : Log::Log4perl->easy_init($ERROR);
+$quiet ? Log::Log4perl->easy_init($ERROR) : Log::Log4perl->easy_init($INFO);
 my $logger = get_logger();
 
 if ($config) {

--- a/scripts/vrtracking_tool
+++ b/scripts/vrtracking_tool
@@ -483,9 +483,9 @@ while (<>) {
                         if ( -d $filepath ) {
                             unless ($test) { remove_tree($filepath) or die "Unable to delete the directory $filepath, error = $!\n" }
 
-                            if ( $fsu->file_exists($filepath) ) {
+                            if ( $fsu->file_exists($filepath, check_path => 1) ) {
                                 unless ($test) {
-                                    if ($fsu->file_exists( $filepath, recurse => 1, wipe_out => 1 ) != 0)
+                                    if ($fsu->file_exists( $filepath, recurse => 1, wipe_out => 1, check_path => 1 ) != 0)
                                     {
                                         die "Unable to delete the directory $filepath from fsu database, error = $!\n";
                                     }
@@ -495,9 +495,9 @@ while (<>) {
                         }
                         elsif ( -e $filepath || ( !-e $filepath && -l $filepath ) ) {
                             unless ($test) { unlink $filepath or die "Unable to delete $filepath, error = $!\n" }
-                            if ( $fsu->file_exists($filepath) ) {
+                            if ( $fsu->file_exists($filepath, check_path => 1) ) {
                                 unless ($test) {
-                                    if ($fsu->file_exists( $filepath, wipe_out => 1 ) != 0)
+                                    if ($fsu->file_exists( $filepath, wipe_out => 1, check_path => 1 ) != 0)
                                     {
                                         die "Unable to delete $filepath from fsu database, error = $!\n";
                                     }

--- a/scripts/vrtracking_tool
+++ b/scripts/vrtracking_tool
@@ -73,7 +73,7 @@ vrtracking_tool
                root    => '/lustre/scratch101/sanger/jm23/TRACKING/',
                db      => 'vrtrack_jm23_neuro',
                [log     => '/lustre/scratch105/log/vrtracking_tool-jm23_neuro.log',] -> optional
-    (If the -v or --verbose flag is used, the information concerning the files/directories deleted and the 
+    (Unless the -q or --quiet flag is used, the information concerning the files/directories deleted and the 
     database objects deleted/flags reset will be written to the log file if specified in the config file.)
  
   NOTE- the tool currently uses names for lanes and studies, hierarchy names for libraries, but only id numbers for samples, 
@@ -95,7 +95,7 @@ vrtracking_tool
               -r,   --root      <root directory for the analyses>          
                         ----------- 
               -s,   --stage     <stage of pipeline to be restarted>
-              -v,   --verbose   <be extra verbose about what it is doing, writes to log file if specified in the config file>
+              -q,   --quiet     <suppress output to stdout/logfile>
               -del, --delete    <use this flag to delete database entries rather than resetting flags>
               -f,   --filter    <filter by reference (mapping/snpcalling) or by assemblier (annotation/assembly)>
               -p,   --prefix    <filter mappings/snp_calling to this mapstats prefix>
@@ -124,7 +124,7 @@ use VRTrack::Lane;
 use Carp;
 use VertRes::Utils::FileSystem;
 
-my ( $config, $config_data, $stage, $help, $delete, $verbose, $root, $db, $test, $reference, $prefix, $assembler, $filter );
+my ( $config, $config_data, $stage, $help, $delete, $quiet, $root, $db, $test, $reference, $prefix, $assembler, $filter );
 
 #values for $stage that involve *resetting* db flags and file deletion
 my @stages = ( 'import', 'qc', 'genotype', 'improved', 'snp_called', 'assembled', 'mapped', 'rna_seq_expression', 'annotated' );
@@ -147,7 +147,7 @@ GetOptions(
     'r|root=s'   => \$root,
     's|stage=s'  => \$stage,
     'del|delete' => \$delete,
-    'v|verbose'  => \$verbose,
+    'q|quiet'    => \$quiet,
     't|test'     => \$test,
     'f|filter=s' => \$filter,
     'p|prefix=s' => \$prefix,
@@ -173,7 +173,7 @@ my $reset_stage = $reset_stages{$stage};
              -r,   --root      <root directory for the analyses>
                         -----------
              -s,   --stage     <stage of pipeline to be restarted>
-             -v,   --verbose   <be extra verbose about what it is doing, writes to log file if specified in the config file>
+             -q,   --quiet     <suppress output to stdout/logfile>
              -del, --delete    <use this flag to delete database entries rather than resetting flags>
              -f,   --filter    <filter by reference (mapping/snpcalling) or by assemblier (annotation/assembly)>
              -p,   --prefix    <filter mappings/snp_calling to this mapstats prefix>
@@ -214,6 +214,7 @@ Examples:
 
 USAGE
 
+my $verbose = !$quiet
 $verbose ? Log::Log4perl->easy_init($INFO) : Log::Log4perl->easy_init($ERROR);
 my $logger = get_logger();
 

--- a/scripts/vrtracking_tool
+++ b/scripts/vrtracking_tool
@@ -98,7 +98,7 @@ vrtracking_tool
               -q,   --quiet     <suppress output to stdout/logfile>
               -del, --delete    <use this flag to delete database entries rather than resetting flags>
               -f,   --filter    <filter by reference (mapping/snpcalling) or by assemblier (annotation/assembly)>
-              -p,   --prefix    <filter mappings/snp_calling to this mapstats prefix>
+              -p,   --prefix    <filter mappings/snp_calling to this mapstats prefix - WARNING: This doesn't work reliably for all data>
               -t,   --test      <use this flag to try the tool without performing any delete/resetting operations>
               -h,   --help      <this message>
               
@@ -176,7 +176,7 @@ my $reset_stage = $reset_stages{$stage};
              -q,   --quiet     <suppress output to stdout/logfile>
              -del, --delete    <use this flag to delete database entries rather than resetting flags>
              -f,   --filter    <filter by reference (mapping/snpcalling) or by assemblier (annotation/assembly)>
-             -p,   --prefix    <filter mappings/snp_calling to this mapstats prefix>
+             -p,   --prefix    <filter mappings/snp_calling to this mapstats prefix - WARNING: This doesn't work reliably for all data>
              -t,   --test      <use this flag to try the tool without performing any delete/resetting operations>
              -h,   --help      <this message>
 

--- a/scripts/vrtracking_tool
+++ b/scripts/vrtracking_tool
@@ -484,7 +484,7 @@ while (<>) {
                         if ( -d $filepath ) {
                             unless ($test) { remove_tree($filepath) or die "Unable to delete the directory $filepath, error = $!\n" }
 
-                            if ( $fsu->file_exists($filepath, check_path => 1) ) {
+                            if ( $fsu->file_exists($filepath) ) {
                                 unless ($test) {
                                     if ($fsu->file_exists( $filepath, recurse => 1, wipe_out => 1 ) != 0)
                                     {
@@ -496,7 +496,7 @@ while (<>) {
                         }
                         elsif ( -e $filepath || ( !-e $filepath && -l $filepath ) ) {
                             unless ($test) { unlink $filepath or die "Unable to delete $filepath, error = $!\n" }
-                            if ( $fsu->file_exists($filepath, check_path => 1) ) {
+                            if ( $fsu->file_exists($filepath) ) {
                                 unless ($test) {
                                     if ($fsu->file_exists( $filepath, wipe_out => 1 ) != 0)
                                     {


### PR DESCRIPTION
- query the 'path' instead of the 'hash' column in the FSU database to avoid issues due to inconsistencies in the md5sum stored in the db and the actual md5sum of the file. This makes sure the vrtracking_tool can actually delete all the files it's supposed to delete
- make the vrtracking_tool verbose by default