### PR TITLE
Removed check if database set to annotation done

### DIFF
--- a/modules/VertRes/Pipelines/AnnotateAssembly.pm
+++ b/modules/VertRes/Pipelines/AnnotateAssembly.pm
@@ -317,8 +317,6 @@ sub update_db {
     
     my $vrtrack = $vrlane->vrtrack;
     
-    return $$self{'Yes'} if $vrlane->is_processed('annotated');
-
     unless($vrlane->is_processed('annotated')){
       $vrtrack->transaction_start();
       $vrlane->is_processed('annotated',1);


### PR DESCRIPTION
If spades and velvet run then the pipeline checks if the database flag has been set to done. If it has it doesn't clean up the intermediate files. This has now been fixed so both can run on the same lane